### PR TITLE
feat: add --expect filename option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ jobs:
           install: false
           command: node . run --passing 1 --failing 1 --config integrationFolder=cypress/failing
 
+      - name: --expect example 1 💎
+        run: npm run test:expect:1
+
+      - name: --expect example 2 💎
+        run: npm run test:expect:2
+
       - name: Semantic Release 🚀
         uses: cycjimmy/semantic-release-action@v2
         env:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,43 @@ The rest of the arguments is parsed using [Cypress CLI method](https://on.cypres
 
 `--pending <N>` checks if the total number of pending tests is `<N>`
 
+`--expect <path/to/file.json>` checks test status against test names in a JSON file, see the details below
+
+### expected test results
+
+The `--expect` option is interesting as it allows you to specify the expected test statuses in a JSON file. Each object key is a suite name, and individual string keys and values are the test names and statuses. For example, the following spec file [cypress/failing/spec.js](./cypress/failing/spec.js) has a suite with 2 tests, first should pass, and the second is expected to fail:
+
+```js
+describe('1 passing 1 failing', () => {
+  it('passes', () => { ... })
+
+  it('fails', () => {
+    expect(true).to.be.false
+  })
+})
+```
+
+You can list the expected test results in a JSON file, for example see [cypress/failing/expected.json](./cypress/failing/expected.json)
+
+```json
+{
+  "1 passing 1 failing": {
+    "passes": "passed",
+    "fails": "fail"
+  }
+}
+```
+
+You can if the tests really behave this way by running:
+
+```shell
+$ npx cypress-expect run --expect ./cypress/failing/expected.json
+```
+
+**Tip:** you do not have to list the passing tests. Every test not listed in the expected JSON is assumed "passing" by default.
+
+**Tip 2:** you do not have to remember the precise name of each test status, the JSON file can use synonyms, like `passed`, `pass`, `passing`, `pass`.
+
 ## Debugging
 
 Run this script with environment variable `DEBUG=cypress-expect` to see verbose logs

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The rest of the arguments is parsed using [Cypress CLI method](https://on.cypres
 
 **Note:** when running in parallel mode where the tests are split, this module would not work, since only a subset of specs will execute on the current machine.
 
+**Tip:** Cypress has 4 test statuses explained in the [Writing and Organizing Tests](http://on.cypress.io/writing-and-organizing-tests#Test-statuses) guide.
+
 ## Options
 
 `--passing <N>` checks if the total number of passing tests is `<N>`

--- a/cypress.json
+++ b/cypress.json
@@ -2,5 +2,6 @@
   "fixturesFolder": false,
   "pluginsFile": false,
   "supportFile": false,
-  "video": false
+  "video": false,
+  "testFiles": "**/*.js"
 }

--- a/cypress/failing/expected.json
+++ b/cypress/failing/expected.json
@@ -1,0 +1,6 @@
+{
+  "1 passing 1 failing": {
+    "passes": "passing",
+    "fails": "failing"
+  }
+}

--- a/cypress/failing/expected.json
+++ b/cypress/failing/expected.json
@@ -1,6 +1,6 @@
 {
   "1 passing 1 failing": {
     "passes": "passed",
-    "fails": "fails"
+    "fails": "fail"
   }
 }

--- a/cypress/failing/expected.json
+++ b/cypress/failing/expected.json
@@ -1,6 +1,6 @@
 {
   "1 passing 1 failing": {
-    "passes": "passing",
-    "fails": "failing"
+    "passes": "passed",
+    "fails": "fails"
   }
 }

--- a/cypress/integration/expected.json
+++ b/cypress/integration/expected.json
@@ -1,0 +1,7 @@
+{
+  "cypress-expect": {
+    "first": "passing",
+    "second": "passing",
+    "third": "passing"
+  }
+}

--- a/index.js
+++ b/index.js
@@ -234,7 +234,7 @@ parseArguments()
           if (test.state !== 'passed') {
             didNotMatch += 1
             console.log(
-              'expected (implicit) the test "%s" to pass, was %s',
+              'cypress-expect: expected implicitly the test "%s" to pass, got %s',
               test.title.join(' / '),
               test.state,
             )
@@ -244,7 +244,7 @@ parseArguments()
           if (test.state !== normalized) {
             didNotMatch += 1
             console.log(
-              'expected the test "%s" to be %s, was %s',
+              'cypress-expect: expected the test "%s" to be %s, got %s',
               test.title.join(' / '),
               normalized,
               test.state,
@@ -255,10 +255,12 @@ parseArguments()
 
       if (didNotMatch) {
         console.error(
-          '%d %s did not match the expected state',
+          'cypress-expect: %d %s did not match the expected state from %s',
           didNotMatch,
           didNotMatch === 1 ? 'test' : 'tests',
+          args['--expect'],
         )
+        console.error('')
         process.exit(1)
       }
 

--- a/index.js
+++ b/index.js
@@ -179,63 +179,61 @@ parseArguments()
       process.exit(1)
     }
 
-    if (runResults.status === 'finished') {
-      const totals = {
-        failed: runResults.totalFailed,
-        passed: runResults.totalPassed,
-        pending: runResults.totalPending,
-      }
-      debug('test totals %o', totals)
+    const totals = {
+      failed: runResults.totalFailed,
+      passed: runResults.totalPassed,
+      pending: runResults.totalPending,
+    }
+    debug('test totals %o', totals)
 
-      if (isFailingSpecified) {
-        if (totals.failed !== args['--failing']) {
-          console.error(
-            'ERROR: expected %d failing tests, got %d',
-            args['--failing'],
-            totals.failed,
-          )
-          process.exit(1)
-        }
-      } else {
-        // any unexpected failed tests are bad
-        if (totals.failed) {
-          console.error('%d test(s) failed', totals.failed)
-          process.exit(totals.failed)
-        }
+    if (isFailingSpecified) {
+      if (totals.failed !== args['--failing']) {
+        console.error(
+          'ERROR: expected %d failing tests, got %d',
+          args['--failing'],
+          totals.failed,
+        )
+        process.exit(1)
       }
-
-      if (isPassingSpecified) {
-        // make sure the expected number of tests executed
-        if (totals.passed !== args['--passing']) {
-          console.error(
-            'ERROR: expected %d passing tests, got %d',
-            args['--passing'],
-            totals.passed,
-          )
-          process.exit(1)
-        }
+    } else {
+      // any unexpected failed tests are bad
+      if (totals.failed) {
+        console.error('%d test(s) failed', totals.failed)
+        process.exit(totals.failed)
       }
+    }
 
-      if (isMinPassingSpecified) {
-        if (totals.passed < args['--min-passing']) {
-          console.error(
-            'ERROR: expected at least %d passing tests, got %d',
-            args['--min-passing'],
-            totals.passed,
-          )
-          process.exit(1)
-        }
+    if (isPassingSpecified) {
+      // make sure the expected number of tests executed
+      if (totals.passed !== args['--passing']) {
+        console.error(
+          'ERROR: expected %d passing tests, got %d',
+          args['--passing'],
+          totals.passed,
+        )
+        process.exit(1)
       }
+    }
 
-      if (isPendingSpecified) {
-        if (totals.pending !== args['--pending']) {
-          console.error(
-            'ERROR: expected %d pending tests, got %d',
-            args['--pending'],
-            totals.pending,
-          )
-          process.exit(1)
-        }
+    if (isMinPassingSpecified) {
+      if (totals.passed < args['--min-passing']) {
+        console.error(
+          'ERROR: expected at least %d passing tests, got %d',
+          args['--min-passing'],
+          totals.passed,
+        )
+        process.exit(1)
+      }
+    }
+
+    if (isPendingSpecified) {
+      if (totals.pending !== args['--pending']) {
+        console.error(
+          'ERROR: expected %d pending tests, got %d',
+          args['--pending'],
+          totals.pending,
+        )
+        process.exit(1)
       }
     }
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -6575,8 +6575,7 @@
     "ramda": {
       "version": "0.27.1",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
-      "dev": true
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
     },
     "rc": {
       "version": "1.2.8",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   ],
   "scripts": {
     "test": "node . run --passing 3",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "test:expect:1": "node . run --expect ./cypress/integration/expected.json",
+    "test:expect:2": "node . run --expect ./cypress/failing/expected.json --config integrationFolder=cypress/failing"
   },
   "repository": {
     "type": "git",
@@ -37,7 +39,7 @@
     "debug": "4.3.1"
   },
   "peerDependencies": {
-    "cypress": ">=5.3.0 || 6.9.1"
+    "cypress": ">=5.3.0"
   },
   "release": {
     "branches": "main"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "dependencies": {
     "arg": "4.1.3",
-    "debug": "4.3.1"
+    "debug": "4.3.1",
+    "ramda": "0.27.1"
   },
   "peerDependencies": {
     "cypress": ">=5.3.0"


### PR DESCRIPTION
- closes #19 
- compares the loaded JSON file against the test results. The JSON should be a subset of the test results, all other tests should be passing.

Added the `--expect` option to specify the expected test statuses in a JSON file. Each object key is a suite name, and individual string keys and values are the test names and statuses. For example, the following spec file has a suite with 2 tests, first should pass, and the second is expected to fail:

```js
describe('1 passing 1 failing', () => {
  it('passes', () => { ... })

  it('fails', () => {
    expect(true).to.be.false
  })
})
```

You can list the expected test results in a JSON file, for example, see "cypress/failing/expected.json" 

```json
{
  "1 passing 1 failing": {
    "passes": "passed",
    "fails": "fail"
  }
}
```

You can if the tests really behave this way by running:

```shell
$ npx cypress-expect run --expect ./cypress/failing/expected.json
```

**Tip:** you do not have to list the passing tests. Every test not listed in the expected JSON is assumed "passing" by default.

**Tip 2:** you do not have to remember the precise name of each test status, the JSON file can use synonyms, like `passed`, `pass`, `passing`, `pass`.